### PR TITLE
Typo in flag - Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A LabVIEW build tool for the G CLI interface
 
 -buildNumber: Sets the build number for the specification, keeping the others as they already are.
 
--versionNubmer: Sets the full version number in the format "d.d.d.d"
+-versionNumber: Sets the full version number in the format "d.d.d.d"
 
 -target: Name of project target to build for. Defaults to "My Computer"
 


### PR DESCRIPTION
versionNumber is correct flag (mentioned as versionNubmer in readme.md)